### PR TITLE
Добавлено падение таски release в случае неуспешного push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-### NEXT_VERSION_TYPE=MAJOR|MINOR|PATCH
+### NEXT_VERSION_TYPE=PATCH
 ### NEXT_VERSION_DESCRIPTION_BEGIN
+* Добавлено падение таски release в случае неуспешного push.
 ### NEXT_VERSION_DESCRIPTION_END
 ## [5.1.0](https://github.com/yoomoney/artifact-release-plugin/pull/22) (26-08-2021)
 

--- a/src/main/kotlin/ru/yoomoney/gradle/plugins/release/PostReleaseTask.kt
+++ b/src/main/kotlin/ru/yoomoney/gradle/plugins/release/PostReleaseTask.kt
@@ -1,6 +1,7 @@
 package ru.yoomoney.gradle.plugins.release
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import ru.yoomoney.gradle.plugins.release.changelog.ChangelogManager
@@ -27,9 +28,14 @@ open class PostReleaseTask : DefaultTask() {
             ChangelogManager(changelogFile).appendNextVersionDescriptionMarkers()
         }
         val releaseExtension = project.extensions.getByType(ReleaseExtension::class.java)
-        GitManager(project.rootDir, gitSettings).use {
+        val resultMessagePush = GitManager(project.rootDir, gitSettings).use {
             it.newVersionCommit(nextVersion, releaseExtension.allowedFilesForCommitRegex)
-            it.push()
+            val resultMessage = it.push()
+            resultMessage
+        }
+
+        if (resultMessagePush != null) {
+            throw GradleException("Push is unsuccessful: resultMessage=$resultMessagePush")
         }
     }
 }

--- a/src/main/kotlin/ru/yoomoney/gradle/plugins/release/git/GitManager.kt
+++ b/src/main/kotlin/ru/yoomoney/gradle/plugins/release/git/GitManager.kt
@@ -75,8 +75,8 @@ class GitManager(private val projectDirectory: File, gitSettings: GitSettings) :
      * Отправляет на удалённый сервер все коммиты и теги
      * @param credentials Права для доступа к репозиторию
      */
-    fun push() {
-        git.push { pushCommand ->
+    fun push(): String? {
+        return git.push { pushCommand ->
             pushCommand
                     .setPushTags()
                     .add(git.repository.fullBranch)


### PR DESCRIPTION
было замечено поведение, что релизная джоба успешна, хотя финальный пуш не прошел